### PR TITLE
feat (contract): functions implementation

### DIFF
--- a/contracts/told_ya/Scarb.lock
+++ b/contracts/told_ya/Scarb.lock
@@ -8,8 +8,8 @@ source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.13.0#97
 
 [[package]]
 name = "snforge_std"
-version = "0.25.0"
-source = "git+https://github.com/foundry-rs/starknet-foundry?tag=v0.25.0#5b366e24821e530fea97f11b211d220e8493fbea"
+version = "0.23.0"
+source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.23.0#f2bff8f796763ada77fe6033ec1b034ceee22abd"
 
 [[package]]
 name = "told_ya"

--- a/contracts/told_ya/Scarb.toml
+++ b/contracts/told_ya/Scarb.toml
@@ -14,6 +14,7 @@ snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag 
 
 [[target.starknet-contract]]
 casm = true
+sierra = true
 
 [scripts]
 test = "snforge test"

--- a/contracts/told_ya/Scarb.toml
+++ b/contracts/told_ya/Scarb.toml
@@ -10,10 +10,10 @@ starknet = "2.6.3"
 openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.13.0" }
 
 [dev-dependencies]
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.25.0" }
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.23.0" }
 
 [[target.starknet-contract]]
-sierra = true
+casm = true
 
 [scripts]
 test = "snforge test"

--- a/contracts/told_ya/src/lib.cairo
+++ b/contracts/told_ya/src/lib.cairo
@@ -13,23 +13,23 @@ pub trait IToldYa<TContractState> {
 
 #[derive(Serde, Drop, Copy, starknet::Store)]
 pub struct Event_ {
-    identifier: felt252,
-    name: felt252,
-    predictions_deadline: felt252,
-    event_datetime: felt252,
-    type_: felt252,
+    pub identifier: felt252,
+    pub name: felt252,
+    pub predictions_deadline: felt252,
+    pub event_datetime: felt252,
+    pub type_: felt252,
 }
 
 #[derive(Serde, Drop, Copy, starknet::Store)]
 pub struct Prediction {
-    identifier: felt252,
-    event_identifier: felt252,
-    value: felt252,
-    creator: ContractAddress,
+    pub identifier: felt252,
+    pub event_identifier: felt252,
+    pub value: felt252,
+    pub creator: ContractAddress,
 }
 
 #[starknet::contract]
-mod Toldya {    
+mod ToldYa {    
 
     use core::poseidon::PoseidonTrait;
     use core::hash::{Hash, HashStateTrait, HashStateExTrait};
@@ -62,8 +62,9 @@ mod Toldya {
     }
 
     #[constructor]
-    fn constructor(ref self: ContractState, initial_owner: super::ContractAddress){
-        self.ownable.initializer(initial_owner);
+    fn constructor(ref self: ContractState){
+        let caller_address = starknet::get_caller_address();
+        self.ownable.initializer(caller_address);
     }
 
     #[abi(embed_v0)]

--- a/contracts/told_ya/src/lib.cairo
+++ b/contracts/told_ya/src/lib.cairo
@@ -101,6 +101,7 @@ mod ToldYa {
 
         fn create_prediction(ref self: ContractState, event_identifier: felt252, value: felt252) -> Prediction {
 
+            //TODO: [PERF] Use the storage var `events_id` to check if the event_identifier is valid.
             // 1) Checking if event_identifier is valid
             let mut events_id: Array<felt252> = self.events_id.read();
             let mut event_id_is_valid: bool = false;

--- a/contracts/told_ya/src/lib.cairo
+++ b/contracts/told_ya/src/lib.cairo
@@ -1,22 +1,26 @@
-use starknet::{ContractAddress};
+use starknet::ContractAddress;
+use openzeppelin::access::ownable::OwnableComponent;
+use core::hash::{Hash, HashStateTrait, HashStateExTrait};
 
 #[starknet::interface]
 pub trait IToldYa<TContractState> {
-    fn create_event(ref self: TContractState, name: ByteArray, predictionsDeadline: ByteArray, eventDatetime: ByteArray, type_: ByteArray) -> Event;
-    fn create_prediction(ref self: TContractState, event_identifier: ByteArray, value: ByteArray) -> Prediction;
-    fn get_events(self: @TContractState) -> Array<Event>;
-    fn get_predictions(self: @TContractState) -> Array<Prediction>;
-    fn get_user_predictions(self: @TContractState, user: ContractAddress) -> Array<Prediction>;
+    fn create_event(ref self: TContractState, name: felt252, predictions_deadline: felt252, event_datetime: felt252, type_: felt252) -> Event_;
+    // fn create_prediction(ref self: TContractState, event_identifier: ByteArray, value: ByteArray) -> Prediction;
+    fn get_events(self: @TContractState) -> Array<Event_>;
+    // fn get_predictions(self: @TContractState) -> Array<Prediction>;
+    // fn get_user_predictions(self: @TContractState, user: ContractAddress) -> Array<Prediction>;
 }
 
-pub struct Event {
-    identifier: ByteArray,
-    name: ByteArray,
-    predictionsDeadline: ByteArray,
-    eventDatetime: ByteArray,
-    type_: ByteArray,
+#[derive(Serde, Drop, Copy, starknet::Store)]
+pub struct Event_ {
+    identifier: felt252,
+    name: felt252,
+    predictions_deadline: felt252,
+    event_datetime: felt252,
+    type_: felt252,
 }
 
+#[derive(Serde, Drop, starknet::Store)]
 pub struct Prediction {
     identifier: ByteArray,
     event_identifier: ByteArray,
@@ -25,45 +29,144 @@ pub struct Prediction {
 }
 
 #[starknet::contract]
-mod Toldya {
+mod Toldya {    
 
-    use starknet::ContractAddress;
-    use openzeppelin::access::ownable::OwnableComponent;
+    use core::poseidon::PoseidonTrait;
+    use core::hash::{Hash, HashStateTrait, HashStateExTrait};
+    use super::Event_;
+    use super::StoreFelt252Array;
 
-    component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
+    component!(path: super::OwnableComponent, storage: ownable, event: OwnableEvent);
 
     #[abi(embed_v0)]
-    impl OwnableImpl = OwnableComponent::OwnableImpl<ContractState>;
+    impl OwnableImpl = super::OwnableComponent::OwnableImpl<ContractState>;
 
-    impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
+    impl OwnableInternalImpl = super::OwnableComponent::InternalImpl<ContractState>;
 
     #[storage]
     struct Storage {
+        events: LegacyMap::<felt252, Event_>,
+        events_id: Array<felt252>,
         #[substorage(v0)]
-        ownable: OwnableComponent::Storage,
-        balance: felt252
+        ownable: super::OwnableComponent::Storage
     }
 
     #[event]
     #[derive(Drop, starknet::Event)]
     enum Event {
-        OwnableEvent: OwnableComponent::Event
+        OwnableEvent: super::OwnableComponent::Event
     }
 
     #[constructor]
-    fn constructor(ref self: ContractState, initial_owner: ContractAddress){
+    fn constructor(ref self: ContractState, initial_owner: super::ContractAddress){
         self.ownable.initializer(initial_owner);
     }
 
     #[abi(embed_v0)]
-    impl HelloStarknetImpl of super::IHelloStarknet<ContractState> {
-        fn increase_balance(ref self: ContractState, amount: felt252) {
-            assert(amount != 0, 'Amount cannot be 0');
-            self.balance.write(self.balance.read() + amount);
+    impl ToldYaImpl of super::IToldYa<ContractState> {
+
+        fn create_event(ref self: ContractState, name: felt252, predictions_deadline: felt252, event_datetime: felt252, type_: felt252) -> Event_ {
+            // 1) Verifying caller is owner
+            self.ownable.assert_only_owner();
+
+            // 2) Hashing the new event
+            let hash_state = PoseidonTrait::new();
+            let hash_result: felt252 = hash_state.update(name).update(predictions_deadline).update(event_datetime).update(type_).finalize();            
+
+            // 3) Creating the instance of the new event
+            let new_event: Event_ = Event_ {
+                identifier: hash_result, 
+                name: name,
+                predictions_deadline: predictions_deadline,
+                event_datetime: event_datetime,
+                type_: type_
+            };
+
+            // 4) Storing the new event in Storage
+            self.events.write(new_event.identifier, new_event);
+
+            // 5) Adding the id to events_id
+            let mut events_id: Array<felt252> = self.events_id.read();
+            events_id.append(new_event.identifier);
+            self.events_id.write(events_id);
+
+            //6) Returning the new event
+            new_event
         }
 
-        fn get_balance(self: @ContractState) -> felt252 {
-            self.balance.read()
+        fn get_events(self: @ContractState) -> Array<Event_> {
+            let mut events_id: Array<felt252> = self.events_id.read();
+            let mut events = ArrayTrait::<Event_>::new();
+            while !events_id.is_empty(){
+                let event_id = events_id.pop_front().unwrap();
+                let event = self.events.read(event_id);
+                events.append(event);
+            };
+            events
         }
+    }
+}
+
+
+
+// This block of code is used to store Array<felt252> in the Storage. 
+// TODO: Move this block in another file and import it in this file.
+impl StoreFelt252Array of starknet::Store<Array<felt252>> {
+    fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<Array<felt252>> {
+        StoreFelt252Array::read_at_offset(address_domain, base, 0)
+    }
+
+    fn write(
+        address_domain: u32, base: starknet::storage_access::StorageBaseAddress, value: Array<felt252>
+    ) -> starknet::SyscallResult<()> {
+        StoreFelt252Array::write_at_offset(address_domain, base, 0, value)
+    }
+
+    fn read_at_offset(
+        address_domain: u32, base: starknet::storage_access::StorageBaseAddress, mut offset: u8
+    ) -> starknet::SyscallResult<Array<felt252>> {
+        let mut arr: Array<felt252> = array![];
+
+        // Read the stored array's length. If the length is greater than 255, the read will fail.
+        let len: u8 = starknet::Store::<u8>::read_at_offset(address_domain, base, offset)
+            .expect('Storage Span too large');
+        offset += 1;
+
+        // Sequentially read all stored elements and append them to the array.
+        let exit = len + offset;
+        loop {
+            if offset >= exit {
+                break;
+            }
+
+            let value = starknet::Store::<felt252>::read_at_offset(address_domain, base, offset).unwrap();
+            arr.append(value);
+            offset += starknet::Store::<felt252>::size();
+        };
+
+        // Return the array.
+        Result::Ok(arr)
+    }
+
+    fn write_at_offset(
+        address_domain: u32, base: starknet::storage_access::StorageBaseAddress, mut offset: u8, mut value: Array<felt252>
+    ) -> starknet::SyscallResult<()> {
+        // Store the length of the array in the first storage slot.
+        let len: u8 = value.len().try_into().expect('Storage - Span too large');
+        starknet::Store::<u8>::write_at_offset(address_domain, base, offset, len).unwrap();
+        offset += 1;
+
+        // Store the array elements sequentially
+        while let Option::Some(element) = value
+            .pop_front() {
+                starknet::Store::<felt252>::write_at_offset(address_domain, base, offset, element).unwrap();
+                offset += starknet::Store::<felt252>::size();
+            };
+
+        Result::Ok(())
+    }
+
+    fn size() -> u8 {
+        255 * starknet::Store::<felt252>::size()
     }
 }

--- a/contracts/told_ya/src/lib.cairo
+++ b/contracts/told_ya/src/lib.cairo
@@ -29,7 +29,7 @@ pub struct Prediction {
 }
 
 #[starknet::contract]
-mod ToldYa {    
+mod ToldYa {
 
     use core::poseidon::PoseidonTrait;
     use core::hash::{Hash, HashStateTrait, HashStateExTrait};
@@ -80,7 +80,7 @@ mod ToldYa {
 
             // 3) Creating the instance of the new event
             let new_event: Event_ = Event_ {
-                identifier: hash_result, 
+                identifier: hash_result,
                 name: name,
                 predictions_deadline: predictions_deadline,
                 event_datetime: event_datetime,
@@ -125,18 +125,18 @@ mod ToldYa {
             // 3) Hashing the new prediction
             let caller_address = starknet::get_caller_address();
             let hash_state = PoseidonTrait::new();
-            let hash_result: felt252 = hash_state.update(event_identifier).update(value).update(caller_address.into()).finalize();    
+            let hash_result: felt252 = hash_state.update(event_identifier).update(value).update(caller_address.into()).finalize();
 
             // 4) Creating the instance of the new prediction
             let new_prediction: Prediction = Prediction {
-                identifier: hash_result, 
+                identifier: hash_result,
                 event_identifier: event_identifier,
                 value: value,
                 creator: caller_address
             };
 
             // 5) Storing the new event in Storage
-            self.predictions.write(new_prediction.identifier, new_prediction);  
+            self.predictions.write(new_prediction.identifier, new_prediction);
 
             // 6) Adding the id to predictions_id
             let mut predictions_id: Array<felt252> = self.predictions_id.read();
@@ -190,7 +190,7 @@ mod ToldYa {
 
 
 
-// This block of code is used to store Array<felt252> in the Storage. 
+// This block of code is used to store Array<felt252> in the Storage.
 // TODO: Move this block in another file and import it in this file.
 impl StoreFelt252Array of starknet::Store<Array<felt252>> {
     fn read(address_domain: u32, base: starknet::storage_access::StorageBaseAddress) -> starknet::SyscallResult<Array<felt252>> {


### PR DESCRIPTION
create_event, get_events

I made some adjustments to the specification:

- I renamed the structure attributes and function entries to follow the snake_case convention, as recommended in the documentation.
- I changed the type of attributes in the Event structure from ByteArray to felt252. This simplifies the hashing process, as the available hashing function takes a felt252 as input and returns a felt252. The idea is to simplify the v1 code and avoid type conversions.
This simplification introduces a new constraint: each attribute value must be a string with a maximum length of 31 characters.

@GROOOOAAAARK let me know your thoughts.